### PR TITLE
Updated Elastika to Sapphire version 2.5.7 - CPU optimizations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,8 @@ endif()
 
 set(ELASTIKA_DIR libs/sapphire/src)
 add_library(elastika-dsp STATIC
-        ${ELASTIKA_DIR}/mesh_hex.cpp
         ${ELASTIKA_DIR}/mesh_physics.cpp
+        ${ELASTIKA_DIR}/elastika_mesh.cpp
         )
 target_include_directories(elastika-dsp PUBLIC ${ELASTIKA_DIR} libs/simde)
 target_compile_definitions(elastika-dsp PUBLIC NO_RACK_DEPENDENCY)


### PR DESCRIPTION
Hi @baconpaul and @bboettcher3 !  I hope you both are doing well as we start 2025.

I know this project has been sitting around a long time, seemingly abandoned, but definitely not forgotten. I feel like I'm finally ready to devote myself to learning JUCE/CLAP/VST, etc this year. I'm starting with this PR that brings Elastika up to date.

Just over this weekend, working with Dan Green at 4ms, I went hard core on optimizing Elastika's CPU usage because the MetaModule hardware simply couldn't cope with its numeric gluttony. So this PR cuts Elastika's CPU overhead by roughly 30-40%. We are now very close to releasing Elastika for MetaModule!

I'm hoping you guys will take a look at this and help me figure out what my next steps would be. Currently, I don't even know how to run this thing. It looks like the build is working correctly on my system, when I run the steps from the readme.

First off, could I possibly run it with Cardinal somehow? I do have Cardinal building on my own system, as I also maintain the Sapphire plugin for it. I have so much to learn and I'm at the far left end of the learning curve...

Thank you so much for all the help getting this far...